### PR TITLE
debian: specify a valid ref in local-options

### DIFF
--- a/debian/source/local-options
+++ b/debian/source/local-options
@@ -1,1 +1,1 @@
-git-ref=v18.4.1
+git-ref=debian/18.4.1


### PR DESCRIPTION
Signed-off-by: Joe MacDonald <joe_macdonald@mentor.com>